### PR TITLE
Update the frontpage's notebook link to new path.

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ background: linear-gradient(90deg, rgba(0,0,0,1) 0%, rgba(20,33,61,1) 0%, rgba(2
 
 <div class="container" style="">
   <div style="height: 100em">
-  <iframe style="border: 0px" scrolling="no" onload="resizeIframe(this)" height="100%" width="100%" src="https://xdsl.dev/xdsl/retro/notebooks/?path=docs/database_example.ipynb"></iframe>
+  <iframe style="border: 0px" scrolling="no" onload="resizeIframe(this)" height="100%" width="100%" src="https://xdsl.dev/xdsl/retro/notebooks/?path=database_example.ipynb"></iframe>
   </div>
   <br>
   <br>


### PR DESCRIPTION
The JupyterLite-related PRs are merged on xDSL and changed the notebooks locations in JupyterLite's hierarchy.
This just update the frontpage's link to work with that.