### PR TITLE
Avoid interactive notebook on page 1

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,11 +18,11 @@ hero: true
 </div>
 
 <div class="container" style="">
-  <div style="height: 100em">
-  <iframe style="border: 0px" scrolling="no" onload="resizeIframe(this)" height="100%" width="100%" src="https://xdsl.dev/xdsl/retro/notebooks/?path=database_example.ipynb"></iframe>
-  </div>
-  <br>
-  <br>
+ <div style="position:relative">
+ <iframe style="border: 0px" height="4000em" scrolling="no" width="100%" src="https://nbviewer.org/github/xdslproject/xdsl/blob/main/docs/database_example.ipynb"></iframe>
+ <a style="position:absolute; top:0; left:0; display:inline-block; width:100%; height:4000em; z-index:5;" href="https://xdsl.dev/xdsl/retro/notebooks/?path=database_example.ipynb">
+ </a>
+ </div>
 </div>
 
 <div class="jumbotron jumbotron-fluid">


### PR DESCRIPTION
Nesting an interactive notebook in an iframe did not work super well. Let's just show the notebook and then link to the interactive one.