### PR TITLE
Populate empty RSS feed

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,13 +47,12 @@ plugins:
     blog_dir: news
     blog_toc: true
 - rss:
-    match_path: blog/posts/.*
+    match_path: (events|news/posts)/.*
     date_from_meta:
       as_creation: date
     categories:
       - categories
       - tags
-
     feeds_filenames:
       rss_created: feed.xml
       rss_updated: feed-updated.xml


### PR DESCRIPTION
Currently, the `match_paths` key of the website RSS generator is wrong, so the RSS feed is empty. This PR fixes it to populate the RSS feed from blog posts and events